### PR TITLE
Bug fix - 'get' method was unable to get classes.jar on Linux

### DIFF
--- a/src/main/groovy/com/noahsloan/atg/ivy/AtgModuleRepository.groovy
+++ b/src/main/groovy/com/noahsloan/atg/ivy/AtgModuleRepository.groovy
@@ -120,7 +120,7 @@ class AtgModuleRepository extends AbstractRepository {
 			def file = new File(filePath)
 			if (file.exists()) {
 				r = new BuiltFileResource(file.absoluteFile)
-				logDebug("file was found: ${r}")
+				log.debug("file was found: ${r}")
 			}
 		}
 


### PR DESCRIPTION
- On UNIX 'get' method couldn't find files, as 'src[6..-1]' returned relavite path, not absolute (e.g. - src = "file:/opt/ATG/ATG11/...", src[6..-1] = "opt/ATG/ATG11.1/...") - fixed
- Added some debug logging, which helped me to find the bug mentioned above
- Little formatting beatify
